### PR TITLE
Revision for Magento best practice

### DIFF
--- a/app/code/community/Ultimate/ModuleCreator/etc/source/app/code/Block/Entity/List/010_top
+++ b/app/code/community/Ultimate/ModuleCreator/etc/source/app/code/Block/Entity/List/010_top
@@ -15,7 +15,7 @@ class {{Namespace}}_{{Module}}_Block_{{Entity}}_List extends Mage_Core_Block_Tem
      * @access public
      * {{qwertyuiop}}
      */
-    public function __construct()
+    public function _construct()
     {
-        parent::__construct();
+        parent::_construct();
         ${{entities}} = Mage::getResourceModel('{{namespace}}_{{module}}/{{entity}}_collection')


### PR DESCRIPTION
Revised so that the _construct method is overridden instead of the __construct method. Magento's core development team encourages this.
